### PR TITLE
Ktor 2

### DIFF
--- a/client/build.gradle.kts
+++ b/client/build.gradle.kts
@@ -12,7 +12,7 @@ dependencies {
     implementation("com.konghq:unirest-java:3.14.2")
     implementation(project(":core"))
     testImplementation(project(":test-core"))
-    testImplementation("com.konghq:unirest-mocks:3.14.2")
+    testImplementation("com.squareup.okhttp3:mockwebserver:4.12.0")
 }
 
 application {

--- a/client/src/main/kotlin/http/ApiResponse.kt
+++ b/client/src/main/kotlin/http/ApiResponse.kt
@@ -1,13 +1,15 @@
 package http
 
-interface ApiResponse<T> {
-    val statusCode: Int
-}
+import kong.unirest.UnirestException
 
-data class SuccessResponse<T>(override val statusCode: Int, val body: T) : ApiResponse<T>
+interface ApiResponse<T>
+
+data class SuccessResponse<T>(val statusCode: Int, val body: T) : ApiResponse<T>
 
 data class FailureResponse<T>(
-    override val statusCode: Int,
+    val statusCode: Int,
     val errorCode: String?,
     val errorMessage: String?
 ) : ApiResponse<T>
+
+data class CommunicationError<T>(val unirestException: UnirestException) : ApiResponse<T>


### PR DESCRIPTION
- Port client-side tests to mockwebserver to allow testing more cases
- Fix missing request body
- Pass requestId as a header
- Handling for UnirestException (e.g. socket timeout)