### PR TITLE
Ditch IP from legacy user connections

### DIFF
--- a/server/src/main/kotlin/auth/UserConnection.kt
+++ b/server/src/main/kotlin/auth/UserConnection.kt
@@ -16,8 +16,8 @@ private val ALL_SOCKETS =
         XmlConstants.SOCKET_NAME_LOBBY
     )
 
-data class UserConnection(val ipAddress: String, val name: String) : IHasId<String> {
-    override val id = ipAddress
+data class UserConnection(val name: String) : IHasId<String> {
+    override val id = name
 
     val colour: String = ColourGenerator.generateNextColour()
     var lastActive: Long = -1
@@ -61,7 +61,7 @@ data class UserConnection(val ipAddress: String, val name: String) : IHasId<Stri
         return hmSocketBySocketName[socketType]
     }
 
-    override fun toString() = "$name @ $ipAddress"
+    override fun toString() = name
 
     fun sendNotificationInWorkerPool(
         message: String?,

--- a/server/src/main/kotlin/routes/session/SessionService.kt
+++ b/server/src/main/kotlin/routes/session/SessionService.kt
@@ -54,7 +54,7 @@ class SessionService(
             }
 
         // Also populate legacy user connection
-        val usc = UserConnection(ip, name)
+        val usc = UserConnection(name)
         usc.setLastActiveNow()
         uscStore.put(usc)
         ServerGlobals.lobbyService.lobbyChanged(usc)
@@ -75,7 +75,7 @@ class SessionService(
     }
 
     fun finishSession(session: Session) {
-        val usc = uscStore.get(session.ip)
+        val usc = uscStore.get(session.name)
         usc.destroyNotificationSockets()
 
         val rooms: List<Room> = ServerGlobals.server.getRooms()
@@ -84,7 +84,7 @@ class SessionService(
             room.removePlayer(usc.name, false)
         }
 
-        uscStore.remove(session.ip)
+        uscStore.remove(session.name)
         sessionStore.remove(session.id)
 
         logger.info("finishSession", "Session ended for ${usc.name}")

--- a/server/src/test/kotlin/routes/lobby/LobbyServiceTest.kt
+++ b/server/src/test/kotlin/routes/lobby/LobbyServiceTest.kt
@@ -57,7 +57,7 @@ class LobbyServiceTest : AbstractTest() {
     fun `Should do nothing if told to exclude the only user`() {
         val server = mockk<EntropyServer>(relaxed = true)
         val (service, _, _, uscStore) = makeService(server = server)
-        val usc = UserConnection("1.2.3.4", "Alyssa")
+        val usc = UserConnection("Alyssa")
         uscStore.put(usc)
         service.lobbyChanged(usc)
 
@@ -68,9 +68,9 @@ class LobbyServiceTest : AbstractTest() {
     fun `Should notify the correct users`() {
         val server = mockk<EntropyServer>(relaxed = true)
         val (service, _, _, uscStore) = makeService(server = server)
-        val uscA = UserConnection("1.2.3.4", "Alyssa")
-        val uscB = UserConnection("5.6.7.8", "Bob")
-        val uscC = UserConnection("0.0.0.0", "Cat")
+        val uscA = UserConnection("Alyssa")
+        val uscB = UserConnection("Bob")
+        val uscC = UserConnection("Cat")
         uscStore.putAll(uscA, uscB, uscC)
 
         service.lobbyChanged(uscA)

--- a/server/src/test/kotlin/routes/session/SessionServiceTest.kt
+++ b/server/src/test/kotlin/routes/session/SessionServiceTest.kt
@@ -136,7 +136,6 @@ class SessionServiceTest : AbstractTest() {
 
         val usc = uscStore.getAll().only()
         usc.name shouldBe "Alyssa"
-        usc.ipAddress shouldBe "1.2.3.4"
     }
 
     @Test

--- a/server/src/test/kotlin/routes/session/SessionServiceTest.kt
+++ b/server/src/test/kotlin/routes/session/SessionServiceTest.kt
@@ -154,10 +154,10 @@ class SessionServiceTest : AbstractTest() {
 
     @Test
     fun `Should support finishing a session`() {
-        val sessionA = makeSession(ip = "1.2.3.4")
+        val sessionA = makeSession(name = "Alyssa")
         val uscA = makeUserConnection(sessionA)
 
-        val sessionB = makeSession(ip = "5.6.7.8")
+        val sessionB = makeSession(name = "Leah")
         val uscB = makeUserConnection(sessionB)
         val (service, sessionStore, uscStore) = makeService()
         sessionStore.putAll(sessionA, sessionB)

--- a/server/src/test/kotlin/store/MemoryUserConnectionStoreTest.kt
+++ b/server/src/test/kotlin/store/MemoryUserConnectionStoreTest.kt
@@ -5,11 +5,11 @@ import auth.UserConnection
 class MemoryUserConnectionStoreTest : AbstractStoreTest<String, UserConnection>() {
     override fun makeStore() = MemoryUserConnectionStore()
 
-    override fun makeIdA() = "1.2.3.A"
+    override fun makeIdA() = "Alyssa"
 
-    override fun makeIdB() = "4.5.6.B"
+    override fun makeIdB() = "Leah"
 
-    override fun makeItemA(id: String) = UserConnection(id, "Alyssa")
+    override fun makeItemA(id: String) = UserConnection(id)
 
-    override fun makeItemB(id: String) = UserConnection(id, "Leah")
+    override fun makeItemB(id: String) = UserConnection(id)
 }

--- a/server/src/test/kotlin/util/TestFactory.kt
+++ b/server/src/test/kotlin/util/TestFactory.kt
@@ -14,7 +14,7 @@ fun makeSession(
     apiVersion: Int = OnlineConstants.API_VERSION,
 ) = Session(id, name, ip, achievementCount, apiVersion)
 
-fun makeUserConnection(session: Session) = UserConnection(session.ip, session.name)
+fun makeUserConnection(session: Session) = UserConnection(session.name)
 
 fun makeGameSettings(
     mode: GameMode = GameMode.Entropy,


### PR DESCRIPTION
UserConnection will be ditched when all the refactors are done, this change just makes it possible to test multiple clients locally in the meantime. 